### PR TITLE
Remove Repl.it and Heroku deployment buttons

### DIFF
--- a/services/nebulaweb/deployment.md
+++ b/services/nebulaweb/deployment.md
@@ -9,10 +9,6 @@ Table of contents
 
 
 ## Quick & Easy Deployment Options
-[![Deploy to Heroku](https://raw.githubusercontent.com/BinBashBanana/deploy-buttons/master/buttons/remade/heroku.svg)](https://heroku.com/deploy/?template=https://github.com/NebulaServices/Nebula)
-<br>
-[![Run on Replit](https://raw.githubusercontent.com/BinBashBanana/deploy-buttons/master/buttons/remade/replit.svg)](https://replit.com/github/NebulaServices/Nebula)
-<br>
 [![Remix on Glitch](https://raw.githubusercontent.com/BinBashBanana/deploy-buttons/master/buttons/remade/glitch.svg)](https://glitch.com/edit/#!/import/github/NebulaServices/Nebula)
 <br>
 [![Deploy to IBM Cloud](https://raw.githubusercontent.com/BinBashBanana/deploy-buttons/master/buttons/remade/ibmcloud.svg)](https://cloud.ibm.com/devops/setup/deploy?repository=https://github.com/NebulaServices/Nebula)


### PR DESCRIPTION
This is the corresponding docs change for NebulaServices/Nebula#116 and NebulaServices/Nebula#117.